### PR TITLE
Attach file on scan

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,6 @@ $('#processBtn').addEventListener('click', async ()=>{
     const file = fileInput.files[0];
     const arrayBuffer = await file.arrayBuffer();
     const hash = await generateHash(arrayBuffer);
-    renderQR(window.location.origin + '/verify?hash=' + hash);
     
     const stampedBytes = await stampPDF(arrayBuffer, hash);
     const blob = new Blob([stampedBytes], {type:'application/pdf'});
@@ -100,6 +99,8 @@ $('#processBtn').addEventListener('click', async ()=>{
             $('#log').appendChild(document.createElement('br'));
             $('#log').appendChild(view);
         }
+        // بعد نجاح الرفع، ولضمان أن QR يشير إلى نسخة الخادم
+        renderQR(window.location.origin + '/file?hash=' + hash);
     } catch(e){
         log('❌ فشل رفع الملف: ' + (e && e.message ? e.message : e));
     }


### PR DESCRIPTION
Add a new `/file` route to serve uploaded PDFs inline and update the frontend to generate QR codes linking to it, allowing users to scan and directly view the full file.

---
<a href="https://cursor.com/background-agent?bcId=bc-30e848df-bc5e-4c1c-b885-eb953102f5c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30e848df-bc5e-4c1c-b885-eb953102f5c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

