### PR TITLE
Fix winansi encoding error for arabic characters

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@ if (typeof QRCode === 'undefined') {
 }
 </script>
 <script src="https://unpkg.com/pdf-lib@1.17.1/dist/pdf-lib.min.js"></script>
+<script src="https://unpkg.com/@pdf-lib/fontkit@1.1.1/dist/fontkit.umd.min.js"></script>
 </head>
 <body>
 
@@ -37,6 +38,19 @@ if (typeof QRCode === 'undefined') {
 <script>
 const $ = s=>document.querySelector(s);
 const log = msg=>{ const d=document.createElement('div'); d.textContent=msg; $('#log').appendChild(d); }
+
+// إعداد خط عربي مضمّن لاستخدامه داخل PDF
+const ARABIC_FONT_URL = 'https://cdn.jsdelivr.net/gh/aliftype/amiri@master/ttf/Amiri-Regular.ttf';
+let cachedArabicFontBytesPromise = null;
+async function getArabicFontBytes(){
+    if(!cachedArabicFontBytesPromise){
+        cachedArabicFontBytesPromise = fetch(ARABIC_FONT_URL).then(r=>{
+            if(!r.ok) throw new Error('تعذر تحميل الخط العربي');
+            return r.arrayBuffer();
+        }).then(buf=>new Uint8Array(buf));
+    }
+    return await cachedArabicFontBytesPromise;
+}
 
 // قاعدة عنوان واجهة البرمجة: تدعم الفتح عبر file:// مباشرةً
 const API_BASE = (location && (location.protocol === 'file:' || location.origin === 'null')) ? 'http://localhost:3000' : '';
@@ -92,7 +106,8 @@ function renderQR(text){
 async function stampPDF(pdfBytes, hash){
     const pdfDoc = await PDFLib.PDFDocument.load(pdfBytes);
     const pages = pdfDoc.getPages();
-    const font = await pdfDoc.embedFont(PDFLib.StandardFonts.Helvetica);
+    pdfDoc.registerFontkit(fontkit);
+    const font = await pdfDoc.embedFont(await getArabicFontBytes(), { subset: true });
     pages.forEach(p=>{
         p.drawText('نسخة أصلية للبنك', { x:20, y:20, size:12, font });
         p.drawText('Hash:'+hash.slice(0,10)+'...', { x:20, y:35, size:8, font });
@@ -162,7 +177,8 @@ $('#processBtn').addEventListener('click', async ()=>{
     // نسخة للعميل بعلامة مائية
     const clientPdfDoc = await PDFLib.PDFDocument.load(arrayBuffer);
     const pages = clientPdfDoc.getPages();
-    const font = await clientPdfDoc.embedFont(PDFLib.StandardFonts.Helvetica);
+    clientPdfDoc.registerFontkit(fontkit);
+    const font = await clientPdfDoc.embedFont(await getArabicFontBytes(), { subset: true });
     pages.forEach(p=>{
         p.drawText('نسخة للعميل – غير أصلية', { x:50, y:50, size:20, font, color:PDFLib.rgb(0.8,0.8,0.8), rotate:PDFLib.degrees(45) });
     });


### PR DESCRIPTION
Embed an Arabic font to enable rendering of Arabic characters in PDFs.

The previous setup used `StandardFonts.Helvetica`, which relies on WinAnsi encoding and cannot render Arabic characters, leading to "WinAnsi cannot encode" errors. This change integrates `fontkit` and embeds a Unicode-compatible Arabic font (Amiri) to correctly display Arabic text in generated PDFs.

---
<a href="https://cursor.com/background-agent?bcId=bc-872304f9-3ee1-4a04-ba65-1cc5e18e019a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-872304f9-3ee1-4a04-ba65-1cc5e18e019a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

