### PR TITLE
Scan barcode not opening file

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,9 +168,9 @@ async function stampPDF(pdfBytes, hash){
     const pages = pdfDoc.getPages();
     pdfDoc.registerFontkit(fontkit);
     const font = await pdfDoc.embedFont(await getArabicFontBytes(), { subset: true });
-    // توليد QR يشير إلى صفحة التحقق
+    // توليد QR يشير مباشرة لعرض الملف على الخادم
     const qrBase = (API_BASE && API_BASE.length) ? API_BASE : window.location.origin;
-    const qrText = qrBase + '/verify?hash=' + hash;
+    const qrText = qrBase + '/file?hash=' + hash;
     const qrDataUrl = await generateQRDataUrl(qrText, 100);
     let qrImage;
     if (qrDataUrl.startsWith('data:image/png')) {
@@ -254,7 +254,7 @@ $('#processBtn').addEventListener('click', async ()=>{
     const font = await clientPdfDoc.embedFont(await getArabicFontBytes(), { subset: true });
     // تضمين QR داخل نسخة العميل أيضًا
     const qrBaseClient = (API_BASE && API_BASE.length) ? API_BASE : window.location.origin;
-    const qrTextClient = qrBaseClient + '/verify?hash=' + hash;
+    const qrTextClient = qrBaseClient + '/file?hash=' + hash;
     const qrDataUrlClient = await generateQRDataUrl(qrTextClient, 90);
     let qrImageClient;
     if (qrDataUrlClient.startsWith('data:image/png')) {

--- a/server.js
+++ b/server.js
@@ -50,7 +50,8 @@ app.get('/verify', (req, res) => {
   const report = reports[hash];
   if(report){
     res.send(`<h2>✅ التقرير أصلي</h2>
-              <p>اسم الملف: ${report.fileName}</p>`);
+              <p>اسم الملف: ${report.fileName}</p>
+              <p><a href="/file?hash=${hash}" target="_blank">📄 عرض الملف</a></p>`);
   } else {
     res.send(`<h2>❌ هذا التقرير غير أصلي أو تم التعديل</h2>`);
   }


### PR DESCRIPTION
Update QR codes to open the file directly and add a "View File" link to the verification page.

This resolves the issue where scanning the QR code would display a verification report instead of opening the actual PDF file.

---
<a href="https://cursor.com/background-agent?bcId=bc-d32f85e1-d6ef-4f77-aa0c-b0f6deaea7ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d32f85e1-d6ef-4f77-aa0c-b0f6deaea7ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

