### PR TITLE
Handle upload server error 405

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,8 +98,11 @@ async function getArabicFontBytes(){
     return await cachedArabicFontBytesPromise;
 }
 
-// قاعدة عنوان واجهة البرمجة: تدعم الفتح عبر file:// مباشرةً
-const API_BASE = (location && (location.protocol === 'file:' || location.origin === 'null')) ? 'http://localhost:3000' : '';
+// قاعدة عنوان واجهة البرمجة: تدعم الفتح عبر file:// مباشرةً، وتُجبِر الاتصال بخادم Node إن لم نكن على نفس الأصل
+const DEFAULT_API_BASE = 'http://localhost:3000';
+const isFileProtocol = location && (location.protocol === 'file:' || location.origin === 'null');
+const isNodeSameOrigin = location && (location.origin === 'http://localhost:3000' || location.origin === 'http://127.0.0.1:3000');
+const API_BASE = isFileProtocol ? DEFAULT_API_BASE : (isNodeSameOrigin ? '' : DEFAULT_API_BASE);
 
 // دالة توليد hash مبسط (SHA-256)
 async function generateHash(fileArrayBuffer){


### PR DESCRIPTION
Configure `API_BASE` in `index.html` to consistently target the Node server, resolving 405 errors during file uploads.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5abda83-f5c6-4611-bf5d-b9b9f877c404">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b5abda83-f5c6-4611-bf5d-b9b9f877c404">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

