### PR TITLE
Fix incorrect link generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,8 +266,10 @@ $('#processBtn').addEventListener('click', async ()=>{
     const targetName = 'original-' + file.name;
     let qrB2Url = '';
     if (cfg && cfg.b2Enabled && cfg.b2PublicBaseUrl && cfg.b2BucketName) {
-        // يجب ترميز اسم الملف في الرابط
-        qrB2Url = cfg.b2PublicBaseUrl.replace(/\/$/, '') + '/file/' + encodeURIComponent(cfg.b2BucketName) + '/' + encodeURIComponent(targetName);
+        // ترميز كل جزء من اسم الملف مع الحفاظ على الشرطة المائلة كفواصل مسارات
+        const safeBucket = encodeURIComponent(cfg.b2BucketName);
+        const safePath = String(targetName).split('/').map(seg => encodeURIComponent(seg)).join('/');
+        qrB2Url = cfg.b2PublicBaseUrl.replace(/\/$/, '') + '/file/' + safeBucket + '/' + safePath;
     }
 
     const stampedBytes = await stampPDF(arrayBuffer, hash, qrB2Url || null);

--- a/server.js
+++ b/server.js
@@ -174,8 +174,14 @@ app.post('/upload', upload.single('file'), async (req, res) => {
       });
 
       // Build a public B2 URL and ensure proper encoding
+      // Important: Preserve path separators in targetName (encode each segment, not the '/')
       const base = (cfg.publicBaseUrl || '').replace(/\/$/, '');
-      const fileUrl = `${base}/file/${encodeURIComponent(cfg.bucketName)}/${encodeURIComponent(targetName)}`;
+      const safeBucket = encodeURIComponent(cfg.bucketName);
+      const safePath = String(targetName)
+        .split('/')
+        .map(seg => encodeURIComponent(seg))
+        .join('/');
+      const fileUrl = `${base}/file/${safeBucket}/${safePath}`;
 
       // سجل الملف في قاعدة البيانات المؤقتة باستخدام الهاش
       reports[hash] = {


### PR DESCRIPTION
Fix incorrect Backblaze URL generation by encoding each path segment while preserving path separators.

---
<a href="https://cursor.com/background-agent?bcId=bc-97b288e6-9f32-4bc8-be93-f9b126690cd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97b288e6-9f32-4bc8-be93-f9b126690cd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

